### PR TITLE
Switch build.bat to use msbuild 14

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,2 +1,2 @@
 @echo off
-"C:\Program Files (x86)\MSBuild\14.0\Bin\msbuild" SignIn.sln /t:Rebuild
+"C:\Program Files (x86)\MSBuild\14.0\Bin\msbuild" SignIn.sln

--- a/build.bat
+++ b/build.bat
@@ -1,2 +1,20 @@
-@echo off
-"C:\Program Files (x86)\MSBuild\14.0\Bin\msbuild" SignIn.sln
+@ECHO OFF
+
+:: Set up the env to use Msbuild 14.0
+IF "%VS140COMNTOOLS%" EQU "" (
+    SET "ERRORMSG=Msbuild 14.0 seems to be not installed)"
+    SET ERRORLEVEL=2
+    GOTO ERROR
+)
+CALL "%VS140COMNTOOLS%\vsvars32.bat"
+
+PUSHD %~dp0
+msbuild
+POPD
+GOTO END
+
+:ERROR
+ECHO %ERRORMSG%
+EXIT /B %ERRORLEVEL%
+
+:END

--- a/build.bat
+++ b/build.bat
@@ -1,23 +1,2 @@
 @echo off
-
-REM Echo Getting Source from GIT
-rem call git --git-dir="%~dp0.git" pull || (GOTO ERROR)
-
-REM call git --git-dir="%~dp0.git" --work-tree="%~dp0" pull && (echo success) || (GOTO ERROR)
-SET FOUND_SOURCE=0
-REM Echo Building Source
-FOR %%i IN (%~dp0src\SignIn\*.csproj) DO ( 
-SET FOUND_SOURCE=1
-REM msbuild %~dp0\src\SignIn\SignIn.csproj && (GOTO ERROR)
-msbuild %%i || (GOTO ERROR)
-)
-
-IF "%FOUND_SOURCE%"=="0" ( echo No source found, check batch argument
-GOTO ERROR  )
-
-GOTO END
-
-:ERROR
-echo Error building!
-
-:END
+"C:\Program Files (x86)\MSBuild\14.0\Bin\msbuild" SignIn.sln /t:Rebuild


### PR DESCRIPTION
This PR fixes build.bat, which stopped working after recent changes to the `develop` branch.